### PR TITLE
fix: Add missing kubernetes requirement in setup.py

### DIFF
--- a/dsls/python/setup.py
+++ b/dsls/python/setup.py
@@ -3,6 +3,7 @@ from distutils.core import setup
 setup(
     name='argo_dataflow',
     packages=['argo_dataflow'],
+    install_requires=['kubernetes'],
     version='v0.0.48',
     license='apache-2.0',
     description='Argo Dataflow',


### PR DESCRIPTION
Fixes the following issue when importing the package:
```
>>> from argo_dataflow import cron, pipeline
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.9/site-packages/argo_dataflow/__init__.py", line 1, in <module>
    from .pipeline import *
  File "/opt/homebrew/lib/python3.9/site-packages/argo_dataflow/pipeline.py", line 4, in <module>
    import kubernetes
ModuleNotFoundError: No module named 'kubernetes'
```


Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>