### PR TITLE
fix: Resolved issue with kafka secret not returning SASL and TLS

### DIFF
--- a/runner/sidecar/kafka.go
+++ b/runner/sidecar/kafka.go
@@ -15,6 +15,13 @@ func kafkaFromSecret(k *dfv1.Kafka, secret *corev1.Secret) error {
 
 	tls := tlsFromSecret(secret)
 	sasl := saslFromSecret(secret)
+
+	if tls == nil && sasl == nil {
+		return nil
+	}
+
+	k.NET = &dfv1.KafkaNET{}
+
 	if tls != nil {
 		k.NET = &dfv1.KafkaNET{TLS: tls}
 	}

--- a/runner/sidecar/kafka.go
+++ b/runner/sidecar/kafka.go
@@ -23,10 +23,10 @@ func kafkaFromSecret(k *dfv1.Kafka, secret *corev1.Secret) error {
 	k.NET = &dfv1.KafkaNET{}
 
 	if tls != nil {
-		k.NET = &dfv1.KafkaNET{TLS: tls}
+		k.NET.TLS = tls
 	}
 	if sasl != nil {
-		k.NET = &dfv1.KafkaNET{SASL: sasl}
+		k.NET.SASL = sasl
 	}
 	return nil
 }

--- a/runner/sidecar/kafka_test.go
+++ b/runner/sidecar/kafka_test.go
@@ -51,6 +51,21 @@ func Test_kafkaFromSecret(t *testing.T) {
 			assert.NotNil(t, x.NET.SASL)
 		}
 	})
+	t.Run("NetSASLAndTLS", func(t *testing.T) {
+		x := &dfv1.Kafka{}
+		err := kafkaFromSecret(x, &corev1.Secret{
+			Data: map[string][]byte{
+				"net.sasl.user":     []byte(""),
+				"net.sasl.password": []byte(""),
+				"net.tls.caCert":    []byte(""),
+			},
+		})
+		assert.NoError(t, err)
+		if assert.NotNil(t, x.NET) {
+			assert.NotNil(t, x.NET.SASL)
+			assert.NotNil(t, x.NET.TLS)
+		}
+	})
 }
 
 func Test_enrichKafka(t *testing.T) {


### PR DESCRIPTION
This PR resolves an issue with Kafka for runner. SASL and TLS is both needed to allow for `sasl_ssl` connections. 
Also resolves issue #627 
Signed-off-by: Kristoffer Olafsen <krise86@users.noreply.github.com>